### PR TITLE
Initial work on setting the client up to save market orders locally on disk.

### DIFF
--- a/assemblers/market.go
+++ b/assemblers/market.go
@@ -82,7 +82,15 @@ func (ma *MarketAssembler) ProcessPacket(packet gopacket.Packet) {
 			ma.itemsBuffer = append(ma.itemsBuffer, udp.Payload[44:]...)
 
 			results := extractStrings(ma.itemsBuffer)
-			utils.SendMarketItems(results, ma.config.IngestUrl, ma.locationId)
+
+			if !ma.config.DisableUpload {
+				utils.SendMarketItems(results, ma.config.IngestUrl, ma.locationId)
+			}
+
+			if ma.config.SaveLocally {
+				utils.SaveMarketItems(results)
+			}
+
 
 			ma.processing = false
 		} else {

--- a/main.go
+++ b/main.go
@@ -17,12 +17,23 @@ func main() {
 
 	flag.StringVar(&config.DeviceName, "d", "", "Specifies the network device name. If not specified the first enumerated device will be used.")
 	flag.StringVar(&config.IngestUrl, "i", "https://albion-market.com/api/v1/ingest/", "URL to send market data to.")
+	flag.BoolVar(&config.DisableUpload, "u", false, "If specified no attempts will be made to upload data to remote server.")
+	flag.BoolVar(&config.SaveLocally, "s", false, "If specified all market orders will be saved locally.")
 	flag.Parse()
 
 	config.DeviceName = networkDeviceName(config.DeviceName)
 
 	log.Printf("Using the following network device: %v", config.DeviceName)
-	log.Printf("Using the following ingest: %v", config.IngestUrl)
+
+	if config.DisableUpload {
+		log.Print("Remote upload of market orders is disabled!")
+	} else {
+		log.Printf("Using the following ingest: %v", config.IngestUrl)
+	}
+
+	if config.SaveLocally {
+		log.Print("Saving market orders locally.")
+	}
 
 	handle, err := pcap.OpenLive(config.DeviceName, 2048, false, pcap.BlockForever)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func main() {
 	config := utils.ClientConfig{}
 
 	flag.StringVar(&config.IngestUrl, "i", "https://albion-market.com/api/v1/ingest/", "URL to send market data to.")
-	flag.BoolVar(&config.DisableUpload, "u", false, "If specified no attempts will be made to upload data to remote server.")
+	flag.BoolVar(&config.DisableUpload, "d", false, "If specified no attempts will be made to upload data to remote server.")
 	flag.BoolVar(&config.SaveLocally, "s", false, "If specified all market orders will be saved locally.")
 	flag.Parse()
 

--- a/utils/file_save.go
+++ b/utils/file_save.go
@@ -11,17 +11,19 @@ func SaveMarketItems(marketItems []string) {
 	date := time.Now().Local().Format("2006-01-02")
 	filename := fmt.Sprintf("marketorder-%v.txt", date)
 
-	f, err := os.OpenFile(filename, os.O_APPEND, 0666)
+	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
 	if err != nil{
 		log.Printf("Error opeing file for saving: %v", err)
+		return
 	}
 
 	defer f.Close()
 
 	for _, order := range marketItems {
-		_, err := f.WriteString(order)
+		_, err := f.WriteString(fmt.Sprintf("%v\n", order))
 		if err != nil {
 			log.Printf("Error appending to file: %v", err)
+			return
 		}
 	}
 

--- a/utils/file_save.go
+++ b/utils/file_save.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"os"
+	"time"
+	"fmt"
+	"log"
+)
+
+func SaveMarketItems(marketItems []string) {
+	date := time.Now().Local().Format("2006-01-02")
+	filename := fmt.Sprintf("marketorder-%v.txt", date)
+
+	f, err := os.OpenFile(filename, os.O_APPEND, 0666)
+	if err != nil{
+		log.Printf("Error opeing file for saving: %v", err)
+	}
+
+	defer f.Close()
+
+	for _, order := range marketItems {
+		_, err := f.WriteString(order)
+		if err != nil {
+			log.Printf("Error appending to file: %v", err)
+		}
+	}
+
+	log.Printf("Saved %v market orders to disk.", len(marketItems))
+}

--- a/utils/types.go
+++ b/utils/types.go
@@ -3,4 +3,6 @@ package utils
 type ClientConfig struct {
 	DeviceName string
 	IngestUrl string
+	DisableUpload bool
+	SaveLocally bool
 }

--- a/utils/types.go
+++ b/utils/types.go
@@ -1,7 +1,6 @@
 package utils
 
 type ClientConfig struct {
-	DeviceName string
 	IngestUrl string
 	DisableUpload bool
 	SaveLocally bool


### PR DESCRIPTION
This also adds a flag to disable uploading market orders to a remote server. While I have hopes that everyone uploads to a central server I don't want to force it on people. People that don't want to are either going to not run it at all, fork, block the requests, or just set the ingest URL to something broken. May as well just make life easier for people and encourage development of this version.

Have not been able to test this yet as I am on lunch and there is a queue to log into the game and the test server client isn't updating.

When completed this should close #5 