### PR TITLE
Fix glide usage

### DIFF
--- a/assemblers/market.go
+++ b/assemblers/market.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
-	"github.com/regner/albionmarket-client/utils"
+	"./utils"
 	"reflect"
 	"regexp"
 	"strings"

--- a/glide.lock
+++ b/glide.lock
@@ -1,14 +1,9 @@
-hash: 968695031d6af1b343306f78a5b55982a5797beb98efbcae2cab6df0fcef9e8f
-updated: 2017-07-28T22:37:27.563785178-07:00
+hash: 923cbc62a933603f4d0a19eeb01099c57db5600cca3e3274e39ce3895be0d154
+updated: 2017-07-29T00:21:30.227656582-07:00
 imports:
 - name: github.com/google/gopacket
   version: 8af772c0bcc826f671fd7c133917fec9686d720d
   subpackages:
   - layers
   - pcap
-- name: github.com/regner/albionmarket-client
-  version: e38a085fad1eb74ba8a3be150f5e34977bfefab7
-  subpackages:
-  - assemblers
-  - utils
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,7 +4,3 @@ import:
   subpackages:
   - layers
   - pcap
-- package: github.com/regner/albionmarket-client
-  subpackages:
-  - assemblers
-  - utils

--- a/main.go
+++ b/main.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/pcap"
-	"github.com/regner/albionmarket-client/assemblers"
-	"github.com/regner/albionmarket-client/utils"
+	"./assemblers"
+	"./utils"
 )
 
 func main() {


### PR DESCRIPTION
I think if you don't use relative paths, it'll actually download your own project into vendor and use those dependencies instead of your own code.

This does mean you should use this project normally and not in a name GO workspace.

What do you think about this? I'm not 100% sure on all this.