### PR TITLE
Setting the glide.yaml package attribute correctly.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,14 +1,9 @@
-hash: 968695031d6af1b343306f78a5b55982a5797beb98efbcae2cab6df0fcef9e8f
-updated: 2017-07-28T22:37:27.563785178-07:00
+hash: 7f4c03142c0914bb64d936ffbd6aedf33f8d2782d437d9bb5ec7b429132692f1
+updated: 2017-07-29T11:16:33.903695209-07:00
 imports:
 - name: github.com/google/gopacket
   version: 8af772c0bcc826f671fd7c133917fec9686d720d
   subpackages:
   - layers
   - pcap
-- name: github.com/regner/albionmarket-client
-  version: e38a085fad1eb74ba8a3be150f5e34977bfefab7
-  subpackages:
-  - assemblers
-  - utils
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,10 +1,6 @@
-package: .
+package: github.com/regner/albionmarket-client
 import:
 - package: github.com/google/gopacket
   subpackages:
   - layers
   - pcap
-- package: github.com/regner/albionmarket-client
-  subpackages:
-  - assemblers
-  - utils


### PR DESCRIPTION
This prevents glide from trying to download this package as a vendor.

This PR supersedes #15 