### PR TITLE
Circle deploy on tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,12 +64,21 @@ workflows:
       - build_windows:
           requires:
             - test
+          filters:
+            tags:
+              only: /.*/
       - build_linux:
           requires:
             - test
+          filters:
+            tags:
+              only: /.*/
       - build_darwin:
           requires:
             - test
+          filters:
+            tags:
+              only: /.*/
       - deploy:
           requires:
             - build_windows
@@ -78,4 +87,6 @@ workflows:
           filters:
             tags:
               only: /^\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,4 @@ workflows:
           filters:
             tags:
               only: /^\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/
 


### PR DESCRIPTION
"Item two above means that a job must have a filters tags section to run as a part of a tag push and all its transitively dependent jobs must also have a filters tags section."

https://circleci.com/docs/2.0/workflows/#git-tag-job-execution