### PR TITLE
Adding location ID to the object

### DIFF
--- a/client/operation_auction_get_offers.go
+++ b/client/operation_auction_get_offers.go
@@ -55,7 +55,6 @@ func (op operationAuctionGetOffersResponse) Process(state *albionState, uploader
 
 	ingestRequest := lib.MarketUpload{
 		Orders:     orders,
-		LocationID: state.LocationId,
 	}
 
 	data, err := json.Marshal(ingestRequest)

--- a/client/operation_auction_get_offers.go
+++ b/client/operation_auction_get_offers.go
@@ -54,7 +54,7 @@ func (op operationAuctionGetOffersResponse) Process(state *albionState, uploader
 	log.Debugf("Sending %d market offers to ingest", len(orders))
 
 	ingestRequest := lib.MarketUpload{
-		Orders:     orders,
+		Orders: orders,
 	}
 
 	data, err := json.Marshal(ingestRequest)

--- a/client/operation_auction_get_offers.go
+++ b/client/operation_auction_get_offers.go
@@ -43,7 +43,7 @@ func (op operationAuctionGetOffersResponse) Process(state *albionState, uploader
 		if err != nil {
 			log.Errorf("Problem converting market order to internal struct: %v", err)
 		}
-
+		order.LocationID = state.LocationId
 		orders = append(orders, order)
 	}
 

--- a/client/operation_auction_get_requests.go
+++ b/client/operation_auction_get_requests.go
@@ -40,7 +40,6 @@ func (op operationAuctionGetRequestsResponse) Process(state *albionState, upload
 
 	ingestRequest := lib.MarketUpload{
 		Orders:     orders,
-		LocationID: state.LocationId,
 	}
 
 	data, err := json.Marshal(ingestRequest)

--- a/client/operation_auction_get_requests.go
+++ b/client/operation_auction_get_requests.go
@@ -39,7 +39,7 @@ func (op operationAuctionGetRequestsResponse) Process(state *albionState, upload
 	log.Debugf("Sending %d market requests to ingest", len(orders))
 
 	ingestRequest := lib.MarketUpload{
-		Orders:     orders,
+		Orders: orders,
 	}
 
 	data, err := json.Marshal(ingestRequest)

--- a/lib/market.go
+++ b/lib/market.go
@@ -15,5 +15,5 @@ type MarketOrder struct {
 
 // MarketUpload contains a list of orders and the location where the orders are from
 type MarketUpload struct {
-	Orders     []*MarketOrder
+	Orders []*MarketOrder
 }

--- a/lib/market.go
+++ b/lib/market.go
@@ -16,5 +16,4 @@ type MarketOrder struct {
 // MarketUpload contains a list of orders and the location where the orders are from
 type MarketUpload struct {
 	Orders     []*MarketOrder
-	LocationID int
 }


### PR DESCRIPTION
Adding the location ID to each order object. CircleCI might fail because it kept trying to format the file using LF (windows newline) while git commits with unix style newlines. If this is a problem, I can resubmit the commit in linux and run the formatting tests.